### PR TITLE
Use Net::SSH::HostKeys for search_for result

### DIFF
--- a/Example.rb
+++ b/Example.rb
@@ -124,7 +124,7 @@ end
 # Let's do it in a way slightly more generic than really needed, so
 # that people can steal the class.
 #
-class MyKnownHost < Array
+class MyKnownHost
 
     # This should, in theory, return a `Net::SSH::HostKeys` object, or
     # at least something that responds to both some unspecified
@@ -140,20 +140,20 @@ class MyKnownHost < Array
     #
     def search_for(host, options = {})
         h = host.split(',')[0]
-        h == @host ? self
-                   : raise("Wrong host: #{h.inspect} (from #{host.inspect})")
+        keys = h == @host ? @host_keys : []
+        ::Net::SSH::HostKeys.new(keys, host, self, options)
     end
 
     attr_reader :host
 
     def initialize(host, pubkeys)
         @host = host
-        super(pubkeys.map { |keyline|
+        @host_keys = pubkeys.map { |keyline|
             type, key = keyline.split(' ', 2)
             # XXX we just assume it's a supported type, yeah, that's lazybad
             blob = key.unpack('m*').first
             Net::SSH::Buffer.new(blob).read_key
-        })
+        }
     end
 
     def add_host_key(key)


### PR DESCRIPTION
I'm digging in [Net::SSH::KnownKeys.search_for](http://www.rubydoc.info/gems/net-ssh/3.2.0/Net/SSH/KnownHosts#search_for-class_method) method and found that use [Net::SSH::HostKeys](http://www.rubydoc.info/gems/net-ssh/3.2.0/Net/SSH/HostKeys) represents as result. So I think `MyKnownHost` should return `HostKeys` too. Then it's unnecessary extends `Array` class.